### PR TITLE
Fix `Session`'s default certificate security check

### DIFF
--- a/tenlib/http.py
+++ b/tenlib/http.py
@@ -129,6 +129,7 @@ class Session(requests.Session):
         self._raw_requote_uri = lambda url: url
         self.hooks = {"response": self._response_hook}
         self.max_connections = max_connections
+        self.verify = verify
         self._build_adapters()
 
     def _build_adapters(self):


### PR DESCRIPTION
Hi,

Session class's `verify` attribute [defaults](https://github.com/cfreal/ten/blob/main/tenlib/http.py#L109) to `False`. This value fails to propagate to the parent class `requests.Session` during instanciation. This is due to the fact that `requests.Session`'s `__init__` method [sets the verify attribute](https://github.com/psf/requests/blob/96b22fa18c00831656ee4b286bf1c9062459b00a/src/requests/sessions.py#L424) to `True`.

This PR fixes this by setting `self.verify` to its default value after calling `super().__init__()`.

Cheers.