### PR TITLE
Add 'date' property to Response object

### DIFF
--- a/tenlib/http.py
+++ b/tenlib/http.py
@@ -10,6 +10,7 @@ import urllib.parse
 from dataclasses import dataclass
 from rich.progress import Progress
 from bs4 import BeautifulSoup
+from datetime import datetime, timezone
 
 import requests
 import requests.adapters
@@ -582,6 +583,18 @@ class Response(requests.Response, struct.Storable):
 
         for redirection in self.session.resolve_redirects(self, self.request):
             return redirection
+
+    @cached_property
+    def date(self) -> int:
+        """Returns the 'Date' header as a UNIX timestamp if it exists, otherwise
+        returns `None`.
+        """
+        if (h := self.headers.get("Date",None)):
+            # RFC 9110 5.6.7 says date must be in GMT
+            h = int(datetime.strptime(h, "%a, %d %b %Y %H:%M:%S GMT")
+                    .replace(tzinfo=timezone.utc)
+                    .timestamp())
+        return h
 
     @cached_property
     def re(self) -> ResponseRegex:

--- a/tenlib/http.py
+++ b/tenlib/http.py
@@ -585,16 +585,15 @@ class Response(requests.Response, struct.Storable):
             return redirection
 
     @cached_property
-    def date(self) -> int:
-        """Returns the 'Date' header as a UNIX timestamp if it exists, otherwise
+    def date(self) -> datetime:
+        """Returns the 'Date' header as a `datetime` object if it exists, otherwise
         returns `None`.
         """
-        if (h := self.headers.get("Date",None)):
+        if (dt := self.headers.get("Date",None)):
             # RFC 9110 5.6.7 says date must be in GMT
-            h = int(datetime.strptime(h, "%a, %d %b %Y %H:%M:%S GMT")
+            dt = datetime.strptime(dt, "%a, %d %b %Y %H:%M:%S GMT")
                     .replace(tzinfo=timezone.utc)
-                    .timestamp())
-        return h
+        return dt
 
     @cached_property
     def re(self) -> ResponseRegex:


### PR DESCRIPTION
When attacking a server that uses the system time to generate a secret, I like to use the server's "Date" response header as an initial guess as the server's clock might not be synced with mine. This PR adds a "date" property to the Response object that will grab the "Date" header from the response (if it exists) and return it as a UNIX timestamp.